### PR TITLE
Expose shows endpoints

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -22,4 +22,4 @@ const getCinemarkData = async () => {
   }
 }
 
-module.exports = getCinemarkData
+module.exports = { getCinemarkData }

--- a/utils/parsers/cinemas.js
+++ b/utils/parsers/cinemas.js
@@ -5,7 +5,7 @@ const parseCinemas = cinemas => {
     const { id, description, name, address, features, decLatitude, decLongitude, urlGoogleMaps, buses } = cinema
 
     return {
-      id,
+      id: String(id),
       description,
       name: parseCinemaName(name),
       coordinates: {

--- a/utils/parsers/movies.js
+++ b/utils/parsers/movies.js
@@ -30,7 +30,7 @@ const parseMovies = async movies => {
       const minAge = rating.split(' ')[0]
 
       const length = `${duration} minutos`
-      const inCinemas = cinemaList.sort((a, b) => a - b)
+      const inCinemas = cinemaList.sort((a, b) => a - b).map(String)
 
       const isPremiere = attributeList.includes(0)
       const categoryParsed = { value: mCategory, emoji: emojifier(mCategory) }

--- a/utils/parsers/shows.js
+++ b/utils/parsers/shows.js
@@ -5,24 +5,24 @@ require('dayjs/locale/es')
 dayjs.locale('es')
 
 const parseShows = movieList => {
-  const showsParsed = movieList
-    .map(({ format, version, cinemaList }) =>
-      cinemaList.map(({ id: cinemaId, sessionList }) => {
-        const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
-          timestamp,
-          date: titleize(dayjs(timestamp).format('dddd D [de] MMMM')),
-          time: dayjs(timestamp).format('HH[:]mm'),
-          link: createTicketsLink(cinemaId, sessionId, featureId),
-          format: format.toUpperCase(),
-          version: titleize(version),
-        }))
+  const [showsParsed] = movieList.map(({ format, version, cinemaList }) => {
+    const cinemaWithShows = cinemaList.map(({ id: cinemaId, sessionList }) => {
+      const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
+        timestamp,
+        date: titleize(dayjs(timestamp).format('dddd D [de] MMMM')),
+        time: dayjs(timestamp).format('HH[:]mm'),
+        link: createTicketsLink(cinemaId, sessionId, featureId),
+        format: format.toUpperCase(),
+        version: titleize(version),
+      }))
 
-        return { cinemaId: String(cinemaId), shows }
-      })
-    )[0]
-    .flat()
+      return { cinemaId: String(cinemaId), shows }
+    })
 
-  return showsParsed
+    return cinemaWithShows
+  })
+
+  return showsParsed.flat()
 }
 
 const createTicketsLink = (cinemaId, sessionId, featureId) => {

--- a/utils/parsers/shows.js
+++ b/utils/parsers/shows.js
@@ -6,19 +6,20 @@ dayjs.locale('es')
 
 const parseShows = movieList => {
   const showsParsed = movieList
-    .map(
-      ({ format, version, cinemaList }) =>
-        cinemaList.map(({ id: cinemaId, sessionList }) =>
-          sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
-            timestamp,
-            date: titleize(dayjs(timestamp).format('dddd D [de] MMMM')),
-            time: dayjs(timestamp).format('HH[:]mm'),
-            link: createTicketsLink(cinemaId, sessionId, featureId),
-            format: format.toUpperCase(),
-            version: titleize(version),
-          }))
-        )[0]
-    )
+    .map(({ format, version, cinemaList }) =>
+      cinemaList.map(({ id: cinemaId, sessionList }) => {
+        const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
+          timestamp,
+          date: titleize(dayjs(timestamp).format('dddd D [de] MMMM')),
+          time: dayjs(timestamp).format('HH[:]mm'),
+          link: createTicketsLink(cinemaId, sessionId, featureId),
+          format: format.toUpperCase(),
+          version: titleize(version),
+        }))
+
+        return { cinemaId: String(cinemaId), shows }
+      })
+    )[0]
     .flat()
 
   return showsParsed

--- a/utils/parsers/shows.js
+++ b/utils/parsers/shows.js
@@ -5,24 +5,25 @@ require('dayjs/locale/es')
 dayjs.locale('es')
 
 const parseShows = movieList => {
-  const [showsParsed] = movieList.map(({ format, version, cinemaList }) => {
-    const cinemaWithShows = cinemaList.map(({ id: cinemaId, sessionList }) => {
-      const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
+  const showsParsed = movieList.map(({ id: formatId, format, version, cinemaList }) => {
+    const cinemaWithShows = cinemaList.reduce((acc, { id: cinemaId, sessionList }) => {
+      const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp, seats }) => ({
+        seats,
         timestamp,
         date: titleize(dayjs(timestamp).format('dddd D [de] MMMM')),
         time: dayjs(timestamp).format('HH[:]mm'),
         link: createTicketsLink(cinemaId, sessionId, featureId),
-        format: format.toUpperCase(),
-        version: titleize(version),
       }))
 
-      return { cinemaId: String(cinemaId), shows }
-    })
+      acc[cinemaId] = shows
 
-    return cinemaWithShows
+      return acc
+    }, {})
+
+    return { formatId, format: titleize(format), version: titleize(version), cinemaWithShows }
   })
 
-  return showsParsed.flat()
+  return showsParsed
 }
 
 const createTicketsLink = (cinemaId, sessionId, featureId) => {

--- a/utils/selectors/index.js
+++ b/utils/selectors/index.js
@@ -1,0 +1,18 @@
+const getMovieById = (movies, movieId) => movies.find(({ id }) => id === movieId)
+
+const getShowsByMovieId = (movies, movieId) => {
+  const movie = getMovieById(movies, movieId)
+  if (!movie) return undefined
+
+  return movie.shows
+}
+
+getShowsByMovieIdAndCinemaId = (movies, movieId, cinemaId) => {
+  const showsPerMovie = getShowsByMovieId(movies, movieId)
+  if (!showsPerMovie) return undefined
+
+  const showsPerCinema = showsPerMovie.find(({ cinemaId: id }) => id === cinemaId)
+  return showsPerCinema
+}
+
+module.exports = { getMovieById, getShowsByMovieId, getShowsByMovieIdAndCinemaId }

--- a/utils/selectors/index.js
+++ b/utils/selectors/index.js
@@ -11,7 +11,15 @@ getShowsByMovieIdAndCinemaId = (movies, movieId, cinemaId) => {
   const showsPerMovie = getShowsByMovieId(movies, movieId)
   if (!showsPerMovie) return null
 
-  const showsPerCinema = showsPerMovie.find(({ cinemaId: id }) => id === cinemaId)
+  const showsPerCinema = showsPerMovie
+    .filter(({ cinemaWithShows }) => cinemaWithShows.hasOwnProperty(cinemaId))
+    .map(shows => {
+      const { cinemaWithShows } = shows
+      const cinemaInShows = cinemaWithShows[cinemaId]
+
+      return { ...shows, cinemaWithShows: { [cinemaId]: cinemaInShows } }
+    })
+
   return showsPerCinema
 }
 

--- a/utils/selectors/index.js
+++ b/utils/selectors/index.js
@@ -2,14 +2,14 @@ const getMovieById = (movies, movieId) => movies.find(({ id }) => id === movieId
 
 const getShowsByMovieId = (movies, movieId) => {
   const movie = getMovieById(movies, movieId)
-  if (!movie) return undefined
+  if (!movie) return null
 
   return movie.shows
 }
 
 getShowsByMovieIdAndCinemaId = (movies, movieId, cinemaId) => {
   const showsPerMovie = getShowsByMovieId(movies, movieId)
-  if (!showsPerMovie) return undefined
+  if (!showsPerMovie) return null
 
   const showsPerCinema = showsPerMovie.find(({ cinemaId: id }) => id === cinemaId)
   return showsPerCinema


### PR DESCRIPTION
This PR will:
- Converts all `ids` to strings
- Remove `shows` payload from `/movies/:id` endpoint
- Adds `/shows/:movieId` endpoint to get all the shows from all the cinemas from a particular movie
- Adds `/shows/:movieId/:cinemaId` endpoint to get all the shows from a particular cinema and movie
