### PR TITLE
Fix shows types

### DIFF
--- a/graphql/types/shows.js
+++ b/graphql/types/shows.js
@@ -4,8 +4,8 @@ const { gql } = ApolloServerFastify;
 
 export default gql`
   type Seats {
-    total: Int!
-    available: Int!
+    total: Int
+    available: Int
   }
 
   type Show {

--- a/utils/parsers/cinemark/shows.js
+++ b/utils/parsers/cinemark/shows.js
@@ -10,6 +10,7 @@ const parseShows = (movieList) => {
   const showsParsed = movieList.map(({ format, version, cinemaList }) => {
     const cinemaWithShows = cinemaList.map(({ id: cinemaId, sessionList }) => {
       const shows = sessionList.map(({ id: sessionId, feature: featureId, dtm: timestamp }) => ({
+        seats: null,
         id: sessionId,
         cinemaId: String(cinemaId),
         version: titleize(version),

--- a/utils/parsers/showcase/index.js
+++ b/utils/parsers/showcase/index.js
@@ -161,6 +161,7 @@ export const scrapShowcaseMoviesAndShows = async (html) => {
                         link,
                         format,
                         version,
+                        seats: null,
                         cinemaId: getCinemaId(cinema),
                         date: dayjs(rawDate).format('YYYY-MM-DD'),
                       };


### PR DESCRIPTION
- [x] Make Seats inner fields nullable
- [x] Add `seats: null` to each show in `Showcase` and `Cinemark` cinema chains since if is null we're going to use their respective AWS Lambda API (Puppeteer), and for Cinépolis we already have the seats data thanks to their API.